### PR TITLE
Fix liquidation module, add client endpoints

### DIFF
--- a/blockchain/app/app_test.go
+++ b/blockchain/app/app_test.go
@@ -44,10 +44,10 @@ func TestApp_Basic(t *testing.T) {
 
 	// Set max bid high to make this test easier
 	// TODO remove with more advanced tests
-	originalMaxBid := liquidator.CollateralAuctionMaxBid
-	liquidator.CollateralAuctionMaxBid = i(100000)
+	originalMaxBid := liquidator.CollateralAuctionSize
+	liquidator.CollateralAuctionSize = i(100000)
 	defer (func() {
-		liquidator.CollateralAuctionMaxBid = originalMaxBid // reset to avoid messing up any other tests
+		liquidator.CollateralAuctionSize = originalMaxBid // reset to avoid messing up any other tests
 	})()
 
 	// Set the current price @ 8k $/BTC

--- a/blockchain/app/app_test.go
+++ b/blockchain/app/app_test.go
@@ -32,23 +32,19 @@ func TestApp_Basic(t *testing.T) {
 	pricefeedGenState := pricefeed.GenesisState{
 		Assets: []pricefeed.Asset{{AssetCode: "btc", Description: ""}},
 	}
+	liquidatorGenState := liquidator.GenesisState{liquidator.LiquidatorModuleParams{
+		CollateralParams: []liquidator.CollateralParams{{Denom: "btc", AuctionSize: i(100)}}, // set high auction size so CDPs are liquidated in one lump
+	}}
 	genState := app.GenesisState{
 		AuthData:      auth.DefaultGenesisState(),
 		BankData:      bank.DefaultGenesisState(),
 		CdpData:       cdp.DefaultGenesisState(),
+		LiquidatorData:       liquidatorGenState,
 		PricefeedData: pricefeedGenState,
 		Accounts:      genAccs,
 	}
 	cdc := app.MakeCodec() // TODO does this need to be `app.cdc` or will this do? Should we export mapp.Cdc ?
 	setGenesis(cdc, mapp, genState)
-
-	// Set max bid high to make this test easier
-	// TODO remove with more advanced tests
-	originalMaxBid := liquidator.CollateralAuctionSize
-	liquidator.CollateralAuctionSize = i(100000)
-	defer (func() {
-		liquidator.CollateralAuctionSize = originalMaxBid // reset to avoid messing up any other tests
-	})()
 
 	// Set the current price @ 8k $/BTC
 	// pricefeed assets were added in genesis, post price message, leave to endblocker for price to be set

--- a/blockchain/x/auction/auctions.go
+++ b/blockchain/x/auction/auctions.go
@@ -2,6 +2,7 @@ package auction
 
 import (
 	"fmt"
+	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -33,7 +34,17 @@ type BaseAuction struct {
 }
 
 type ID uint64
+
+func NewIDFromString(s string) (ID, error) {
+	n, err := strconv.ParseUint(s, 10, 64) // copied from how the gov module rest handler's parse proposal IDs
+	if err != nil {
+		return 0, err
+	}
+	return ID(n), nil
+}
+
 type endTime int64 // TODO rename to Blockheight or don't define custom type
+
 // Initially the input and output types from the bank module where used here. But they use sdk.Coins instad of sdk.Coin. So it caused a lot of type conversion as auction mainly uses sdk.Coin.
 type bankInput struct {
 	Address sdk.AccAddress

--- a/blockchain/x/auction/client/cli/tx.go
+++ b/blockchain/x/auction/client/cli/tx.go
@@ -24,7 +24,11 @@ func GetCmdPlaceBid(cdc *codec.Codec) *cobra.Command {
 			if err := cliCtx.EnsureAccountExists(); err != nil {
 				return err
 			}
-			id := sdk.NewUintFromString(args[0])
+			id, err := auction.NewIDFromString(args[0])
+			if err != nil {
+				fmt.Printf("invalid auction id - %s \n", string(args[0]))
+				return err
+			}
 
 			bid, err := sdk.ParseCoin(args[2])
 			if err != nil {
@@ -37,7 +41,7 @@ func GetCmdPlaceBid(cdc *codec.Codec) *cobra.Command {
 				fmt.Printf("invalid lot - %s \n", string(args[3]))
 				return err
 			}
-			msg := auction.NewMsgPlaceBid(id.Uint64(), cliCtx.GetFromAddress(), bid, lot)
+			msg := auction.NewMsgPlaceBid(id, cliCtx.GetFromAddress(), bid, lot)
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err

--- a/blockchain/x/auction/client/rest/rest.go
+++ b/blockchain/x/auction/client/rest/rest.go
@@ -57,7 +57,11 @@ func bidHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc 
 		strBid := vars[restBid]
 		strLot := vars[restLot]
 
-		auctionID := sdk.NewUintFromString(strAuctionID)
+		auctionID, err := auction.NewIDFromString(strAuctionID)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
 
 		bidder, err := sdk.AccAddressFromBech32(bechBidder)
 		if err != nil {
@@ -77,7 +81,7 @@ func bidHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc 
 			return
 		}
 
-		msg := auction.NewMsgPlaceBid(auctionID.Uint64(), bidder, bid, lot)
+		msg := auction.NewMsgPlaceBid(auctionID, bidder, bid, lot)
 		clientrest.WriteGenerateStdTxResponse(w, cdc, cliCtx, req.BaseReq, []sdk.Msg{msg})
 
 	}

--- a/blockchain/x/cdp/keeper.go
+++ b/blockchain/x/cdp/keeper.go
@@ -240,17 +240,17 @@ func (k Keeper) GetGovDenom() string {
 	return GovDenom
 }
 
-// ---------- Parameter Fetching ----------
+// ---------- Module Parameters ----------
 
 func (k Keeper) GetParams(ctx sdk.Context) CdpModuleParams {
 	var p CdpModuleParams
-	k.paramsSubspace.Get(ctx, cdpModuleParamsKey, &p)
+	k.paramsSubspace.Get(ctx, moduleParamsKey, &p)
 	return p
 }
 
 // This is only needed to be able to setup the store from the genesis file. The keeper should not change any of the params itself.
 func (k Keeper) setParams(ctx sdk.Context, cdpModuleParams CdpModuleParams) {
-	k.paramsSubspace.Set(ctx, cdpModuleParamsKey, &cdpModuleParams)
+	k.paramsSubspace.Set(ctx, moduleParamsKey, &cdpModuleParams)
 }
 
 // ---------- Store Wrappers ----------

--- a/blockchain/x/cdp/keeper_test.go
+++ b/blockchain/x/cdp/keeper_test.go
@@ -182,9 +182,9 @@ func TestKeeper_PartialSeizeCDP(t *testing.T) {
 	require.NoError(t, err)
 	_, found := keeper.GetCDP(ctx, testAddr, collateral)
 	require.False(t, found)
-	cState, found := keeper.GetCollateralState(ctx, collateral)
+	collateralState, found := keeper.GetCollateralState(ctx, collateral)
 	require.True(t, found)
-	require.Equal(t, sdk.ZeroInt(), cState.TotalDebt)
+	require.Equal(t, sdk.ZeroInt(), collateralState.TotalDebt)
 }
 func TestKeeper_GetSetDeleteCDP(t *testing.T) {
 	// setup keeper, create CDP
@@ -232,13 +232,13 @@ func TestKeeper_GetSetCollateralState(t *testing.T) {
 	header := abci.Header{Height: mapp.LastBlockHeight() + 1}
 	mapp.BeginBlock(abci.RequestBeginBlock{Header: header})
 	ctx := mapp.BaseApp.NewContext(false, header)
-	cState := CollateralState{"xrp", i(15400)}
+	collateralState := CollateralState{"xrp", i(15400)}
 
 	// write and read from store
-	keeper.setCollateralState(ctx, cState)
-	readCState, found := keeper.GetCollateralState(ctx, cState.Denom)
+	keeper.setCollateralState(ctx, collateralState)
+	readCState, found := keeper.GetCollateralState(ctx, collateralState.Denom)
 
 	// check before and after match
-	require.Equal(t, cState, readCState)
+	require.Equal(t, collateralState, readCState)
 	require.True(t, found)
 }

--- a/blockchain/x/cdp/keeper_test.go
+++ b/blockchain/x/cdp/keeper_test.go
@@ -107,7 +107,7 @@ func TestKeeper_ModifyCDP(t *testing.T) {
 			keeper.pricefeed.SetPrice(
 				ctx, sdk.AccAddress{}, "xrp",
 				sdk.MustNewDecFromStr(tc.price),
-				sdk.NewInt(10))
+				i(10))
 			keeper.pricefeed.SetCurrentPrices(ctx)
 			if tc.priorState.CDP.CollateralDenom != "" { // check if the prior CDP should be created or not (see if an empty one was specified)
 				keeper.setCDP(ctx, tc.priorState.CDP)
@@ -147,7 +147,8 @@ func TestKeeper_ModifyCDP(t *testing.T) {
 	}
 }
 
-func TestKeeper_SeizeCDP(t *testing.T) {
+// TODO change to table driven test to test more test cases
+func TestKeeper_PartialSeizeCDP(t *testing.T) {
 	// Setup
 	const collateral = "xrp"
 	mapp, keeper := setUpMockAppWithoutGenesis()
@@ -158,27 +159,27 @@ func TestKeeper_SeizeCDP(t *testing.T) {
 	header := abci.Header{Height: mapp.LastBlockHeight() + 1}
 	mapp.BeginBlock(abci.RequestBeginBlock{Header: header})
 	ctx := mapp.BaseApp.NewContext(false, header)
-	keeper.pricefeed.AddAsset(ctx, collateral, "xrp test")
+	keeper.pricefeed.AddAsset(ctx, collateral, "test description") 
 	keeper.pricefeed.SetPrice(
 		ctx, sdk.AccAddress{}, collateral,
 		sdk.MustNewDecFromStr("1.00"),
-		sdk.NewInt(10))
+		i(10))
 	keeper.pricefeed.SetCurrentPrices(ctx)
 	// Create CDP
 	err := keeper.ModifyCDP(ctx, testAddr, collateral, i(10), i(5))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// Reduce price
 	keeper.pricefeed.SetPrice(
 		ctx, sdk.AccAddress{}, collateral,
 		sdk.MustNewDecFromStr("0.90"),
-		sdk.NewInt(10))
+		i(10))
 	keeper.pricefeed.SetCurrentPrices(ctx)
 
-	// Seize CDP
-	_, err = keeper.SeizeCDP(ctx, testAddr, collateral)
+	// Seize entire CDP
+	err = keeper.PartialSeizeCDP(ctx, testAddr, collateral, i(10), i(5))
 
 	// Check
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, found := keeper.GetCDP(ctx, testAddr, collateral)
 	require.False(t, found)
 	cState, found := keeper.GetCollateralState(ctx, collateral)
@@ -192,7 +193,7 @@ func TestKeeper_GetSetDeleteCDP(t *testing.T) {
 	mapp.BeginBlock(abci.RequestBeginBlock{Header: header})
 	ctx := mapp.BaseApp.NewContext(false, header)
 	_, addrs := mock.GeneratePrivKeyAddressPairs(1)
-	cdp := CDP{addrs[0], "xrp", sdk.NewInt(412), sdk.NewInt(56)}
+	cdp := CDP{addrs[0], "xrp", i(412), i(56)}
 
 	// write and read from store
 	keeper.setCDP(ctx, cdp)
@@ -215,7 +216,7 @@ func TestKeeper_GetSetGDebt(t *testing.T) {
 	header := abci.Header{Height: mapp.LastBlockHeight() + 1}
 	mapp.BeginBlock(abci.RequestBeginBlock{Header: header})
 	ctx := mapp.BaseApp.NewContext(false, header)
-	gDebt := sdk.NewInt(4120000)
+	gDebt := i(4120000)
 
 	// write and read from store
 	keeper.setGlobalDebt(ctx, gDebt)
@@ -231,7 +232,7 @@ func TestKeeper_GetSetCollateralState(t *testing.T) {
 	header := abci.Header{Height: mapp.LastBlockHeight() + 1}
 	mapp.BeginBlock(abci.RequestBeginBlock{Header: header})
 	ctx := mapp.BaseApp.NewContext(false, header)
-	cState := CollateralState{"xrp", sdk.NewInt(15400)}
+	cState := CollateralState{"xrp", i(15400)}
 
 	// write and read from store
 	keeper.setCollateralState(ctx, cState)

--- a/blockchain/x/liquidator/client/cli/query.go
+++ b/blockchain/x/liquidator/client/cli/query.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+
+	"github.com/kava-labs/usdx/blockchain/x/liquidator"
+)
+
+// GetCmd_GetOutstandingDebt queries for the remaining available debt in the liquidator module after settlement.
+func GetCmd_GetOutstandingDebt(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "debt",
+		Short: "get the outstanding seized debt",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, liquidator.QueryGetOutstandingDebt), nil)
+			if err != nil {
+				return err
+			}
+			var outstandingDebt sdk.Int
+			cdc.MustUnmarshalJSON(res, &outstandingDebt)
+			return cliCtx.PrintOutput(outstandingDebt)
+		},
+	}
+}

--- a/blockchain/x/liquidator/client/cli/query.go
+++ b/blockchain/x/liquidator/client/cli/query.go
@@ -11,11 +11,12 @@ import (
 	"github.com/kava-labs/usdx/blockchain/x/liquidator"
 )
 
-// GetCmd_GetOutstandingDebt queries for the remaining available debt in the liquidator module after settlement.
+// GetCmd_GetOutstandingDebt queries for the remaining available debt in the liquidator module after settlement with the module's stablecoin balance.
 func GetCmd_GetOutstandingDebt(queryRoute string, cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "debt",
 		Short: "get the outstanding seized debt",
+		Long:  "Get the remaining available debt after settlement with the liquidator's stable coin balance.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)

--- a/blockchain/x/liquidator/client/cli/tx.go
+++ b/blockchain/x/liquidator/client/cli/tx.go
@@ -15,8 +15,12 @@ func GetCmd_SeizeAndStartCollateralAuction(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "seize [cdp-owner] [collateral-denom]",
 		Short: "seize funds from a CDP and send to auction",
-		Long:  "Seize a fixed amount of collateral and debt from a CDP and start a 'forward-reverse' auction with the collateral to cover the debt.",
-		Args:  cobra.ExactArgs(2),
+		Long: `Seize a fixed amount of collateral and debt from a CDP then start an auction with the collateral.
+The amount of collateral seized is given by the 'AuctionSize' module parameter or, if there isn't enough collateral in the CDP, all the CDP's collateral is seized.
+Debt is seized in proportion to the collateral seized so that the CDP stays at the same collateral to debt ratio.
+A 'forward-reverse' auction is started selling the seized collateral for some stable coin, with a maximum bid of stable coin set to equal the debt seized.
+As this is a forward-reverse auction type, if the max stable coin is bid then bidding continues by bidding down the amount of collateral taken by the bidder. At the end, extra collateral is returned to the original CDP owner.`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Setup
 			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))

--- a/blockchain/x/liquidator/client/cli/tx.go
+++ b/blockchain/x/liquidator/client/cli/tx.go
@@ -52,7 +52,7 @@ As this is a forward-reverse auction type, if the max stable coin is bid then bi
 
 func GetCmd_StartDebtAuction(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "mint", // TODO is this a reasonable name?
+		Use:   "mint",
 		Short: "start a debt auction, minting gov coin to cover debt",
 		Long:  "Start a reverse auction, selling off minted gov coin to raise a fixed amount of stable coin.",
 		Args:  cobra.NoArgs,

--- a/blockchain/x/liquidator/client/cli/tx.go
+++ b/blockchain/x/liquidator/client/cli/tx.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/utils"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
+	"github.com/spf13/cobra"
+
+	"github.com/kava-labs/usdx/blockchain/x/liquidator"
+)
+
+func GetCmd_SeizeAndStartCollateralAuction(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "seize [cdp-owner] [collateral-denom]",
+		Short: "seize funds from a CDP and send to auction",
+		Long:  "Seize a fixed amount of collateral and debt from a CDP and start a 'forward-reverse' auction with the collateral to cover the debt.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Setup
+			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
+			cliCtx := context.NewCLIContext().
+				WithCodec(cdc).
+				WithAccountDecoder(cdc)
+
+			// Validate inputs
+			sender := cliCtx.GetFromAddress()
+			cdpOwner, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+			denom := args[1]
+			// TODO validate denom?
+
+			// Prepare and send message
+			msgs := []sdk.Msg{liquidator.MsgSeizeAndStartCollateralAuction{
+				Sender:          sender,
+				CdpOwner:        cdpOwner,
+				CollateralDenom: denom,
+			}}
+			// TODO print out results like auction ID?
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgs, false)
+		},
+	}
+	return cmd
+}
+
+func GetCmd_StartDebtAuction(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mint", // TODO is this a reasonable name?
+		Short: "start a debt auction, minting gov coin to cover debt",
+		Long:  "Start a reverse auction, selling off minted gov coin to raise a fixed amount of stable coin.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Setup
+			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			sender := cliCtx.GetFromAddress()
+
+			// Prepare and send message
+			msgs := []sdk.Msg{liquidator.MsgStartDebtAuction{
+				Sender: sender,
+			}}
+			// TODO print out results like auction ID?
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgs, false)
+		},
+	}
+	return cmd
+}

--- a/blockchain/x/liquidator/client/module_client.go
+++ b/blockchain/x/liquidator/client/module_client.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/spf13/cobra"
+	amino "github.com/tendermint/go-amino"
+
+	"github.com/kava-labs/usdx/blockchain/x/liquidator/client/cli"
+)
+
+// ModuleClient exports all client functionality from this module
+type ModuleClient struct {
+	storeKey string
+	cdc      *amino.Codec
+}
+
+// NewModuleClient creates client for the module
+func NewModuleClient(storeKey string, cdc *amino.Codec) ModuleClient {
+	return ModuleClient{storeKey, cdc}
+}
+
+// GetQueryCmd returns the cli query commands for this module
+func (mc ModuleClient) GetQueryCmd() *cobra.Command {
+	queryCmd := &cobra.Command{
+		Use:   "liquidator",
+		Short: "Querying commands for the liquidator module",
+	}
+
+	queryCmd.AddCommand(client.GetCommands(
+		cli.GetCmd_GetOutstandingDebt(mc.storeKey, mc.cdc),
+	)...)
+
+	return queryCmd
+}
+
+// GetTxCmd returns the transaction commands for this module
+func (mc ModuleClient) GetTxCmd() *cobra.Command {
+	txCmd := &cobra.Command{
+		Use:   "liquidator",
+		Short: "Liquidator transactions subcommands",
+	}
+
+	txCmd.AddCommand(client.PostCommands(
+		cli.GetCmd_SeizeAndStartCollateralAuction(mc.cdc),
+		cli.GetCmd_StartDebtAuction(mc.cdc),
+	)...)
+
+	return txCmd
+}

--- a/blockchain/x/liquidator/client/rest/rest.go
+++ b/blockchain/x/liquidator/client/rest/rest.go
@@ -1,0 +1,100 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	clientrest "github.com/cosmos/cosmos-sdk/client/rest"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+	"github.com/gorilla/mux"
+
+	"github.com/kava-labs/usdx/blockchain/x/liquidator"
+)
+
+// RegisterRoutes - Central function to define routes that get registered by the main application
+func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *codec.Codec) {
+	r.HandleFunc("/liquidator/outstandingdebt", queryDebtHandlerFn(cdc, cliCtx)).Methods("GET")
+	r.HandleFunc("/liquidator/seize", seizeCdpHandlerFn(cdc, cliCtx)).Methods("POST")
+	r.HandleFunc("/liquidator/mint", debtAuctionHandlerFn(cdc, cliCtx)).Methods("POST")
+	// r.HandleFunc("liquidator/burn", surplusAuctionHandlerFn(cdc, cliCtx).Methods("POST"))
+}
+
+func queryDebtHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/liquidator/%s", liquidator.QueryGetOutstandingDebt), nil) // TODO should these functions have 'liquidator' passed in as arg, like queriers?
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		rest.PostProcessResponse(w, cdc, res, cliCtx.Indent) // write JSON to response writer
+	}
+}
+
+type SeizeAndStartCollateralAuctionRequest struct {
+	BaseReq         rest.BaseReq   `json:"base_req"`
+	Sender          sdk.AccAddress `json:"sender"`
+	CdpOwner        sdk.AccAddress `json:"cdp_owner"`
+	CollateralDenom string         `json:"collateral_denom"`
+}
+
+func seizeCdpHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Get args from post body
+		var req SeizeAndStartCollateralAuctionRequest
+		if !rest.ReadRESTReq(w, r, cdc, &req) { // This function writes a response on error
+			return
+		}
+		req.BaseReq = req.BaseReq.Sanitize()
+		if !req.BaseReq.ValidateBasic(w) { // This function writes a response on error
+			return
+		}
+
+		// Create msg
+		msg := liquidator.MsgSeizeAndStartCollateralAuction{
+			req.Sender,
+			req.CdpOwner,
+			req.CollateralDenom,
+		}
+		if err := msg.ValidateBasic(); err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		// Generate tx and write response
+		clientrest.WriteGenerateStdTxResponse(w, cdc, cliCtx, req.BaseReq, []sdk.Msg{msg})
+	}
+}
+
+type StartDebtAuctionRequest struct {
+	BaseReq rest.BaseReq   `json:"base_req"`
+	Sender  sdk.AccAddress `json:"sender"` // TODO use baseReq.From instead?
+}
+
+func debtAuctionHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Get args from post body
+		var req StartDebtAuctionRequest
+		if !rest.ReadRESTReq(w, r, cdc, &req) {
+			return
+		}
+		req.BaseReq = req.BaseReq.Sanitize()
+		if !req.BaseReq.ValidateBasic(w) {
+			return
+		}
+
+		// Create msg
+		msg := liquidator.MsgStartDebtAuction{
+			req.Sender,
+		}
+		if err := msg.ValidateBasic(); err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		// Generate tx and write response
+		clientrest.WriteGenerateStdTxResponse(w, cdc, cliCtx, req.BaseReq, []sdk.Msg{msg})
+	}
+}

--- a/blockchain/x/liquidator/client/rest/rest.go
+++ b/blockchain/x/liquidator/client/rest/rest.go
@@ -24,7 +24,7 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *codec.Codec) 
 
 func queryDebtHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/liquidator/%s", liquidator.QueryGetOutstandingDebt), nil) // TODO should these functions have 'liquidator' passed in as arg, like queriers?
+		res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/liquidator/%s", liquidator.QueryGetOutstandingDebt), nil)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return

--- a/blockchain/x/liquidator/codec.go
+++ b/blockchain/x/liquidator/codec.go
@@ -10,7 +10,7 @@ func init() {
 
 // RegisterCodec registers concrete types on the codec.
 func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterConcrete(MsgStartCollateralAuction{}, "liquidator/MsgStartCollateralAuction", nil)
+	cdc.RegisterConcrete(MsgSeizeAndStartCollateralAuction{}, "liquidator/MsgSeizeAndStartCollateralAuction", nil)
 	cdc.RegisterConcrete(MsgStartDebtAuction{}, "liquidator/MsgStartDebtAuction", nil)
 	// cdc.RegisterConcrete(MsgStartSurplusAuction{}, "liquidator/MsgStartSurplusAuction", nil)
 }

--- a/blockchain/x/liquidator/codec.go
+++ b/blockchain/x/liquidator/codec.go
@@ -10,7 +10,7 @@ func init() {
 
 // RegisterCodec registers concrete types on the codec.
 func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterConcrete(MsgSeizeAndStartCollateralAuction{}, "liquidator/MsgSeizeAndStartCollateralAuction", nil)
+	cdc.RegisterConcrete(MsgStartCollateralAuction{}, "liquidator/MsgStartCollateralAuction", nil)
 	cdc.RegisterConcrete(MsgStartDebtAuction{}, "liquidator/MsgStartDebtAuction", nil)
 	// cdc.RegisterConcrete(MsgStartSurplusAuction{}, "liquidator/MsgStartSurplusAuction", nil)
 }

--- a/blockchain/x/liquidator/codec.go
+++ b/blockchain/x/liquidator/codec.go
@@ -12,5 +12,5 @@ func init() {
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgSeizeAndStartCollateralAuction{}, "liquidator/MsgSeizeAndStartCollateralAuction", nil)
 	cdc.RegisterConcrete(MsgStartDebtAuction{}, "liquidator/MsgStartDebtAuction", nil)
-	cdc.RegisterConcrete(MsgStartSurplusAuction{}, "liquidator/MsgStartSurplusAuction", nil)
+	// cdc.RegisterConcrete(MsgStartSurplusAuction{}, "liquidator/MsgStartSurplusAuction", nil)
 }

--- a/blockchain/x/liquidator/doc.go
+++ b/blockchain/x/liquidator/doc.go
@@ -12,11 +12,8 @@ Notes
 	- liquidator needs get access to stable and gov denoms from the cdp module
 
 TODO
- - FIX: after a CDP is seized, users can create a new one, which if also seized will collide with prexisting seized CDP
  - Add some kind of more complete test
- - Add an endblocker that seizes all undercollateralized CDPs (requires queue structure in CDP module)
  - Add params (need access to the collateral types for fees. Can this module access the cdp module params?)
- - rename SeizedDebt to TotalSeizedDebt ?
  - Add constants for the module and route names
  - user facing things like cli, rest, querier, tags
  - custom error types, codespace

--- a/blockchain/x/liquidator/doc.go
+++ b/blockchain/x/liquidator/doc.go
@@ -13,9 +13,8 @@ Notes
 
 TODO
  - Add some kind of more complete test
- - Add params (need access to the collateral types for fees. Can this module access the cdp module params?)
  - Add constants for the module and route names
- - user facing things like cli, rest, querier, tags
+ - tags
  - custom error types, codespace
 */
 package liquidator

--- a/blockchain/x/liquidator/doc.go
+++ b/blockchain/x/liquidator/doc.go
@@ -12,6 +12,7 @@ Notes
 	- liquidator needs get access to stable and gov denoms from the cdp module
 
 TODO
+ - FIX: after a CDP is seized, users can create a new one, which if also seized will collide with prexisting seized CDP
  - Add some kind of more complete test
  - Add an endblocker that seizes all undercollateralized CDPs (requires queue structure in CDP module)
  - Add params (need access to the collateral types for fees. Can this module access the cdp module params?)

--- a/blockchain/x/liquidator/doc.go
+++ b/blockchain/x/liquidator/doc.go
@@ -12,6 +12,7 @@ Notes
 	- liquidator needs get access to stable and gov denoms from the cdp module
 
 TODO
+ - Is returning unsold collateral to the CDP owner rather than the CDP a problem? It could prevent the CDP from becoming safe again.
  - Add some kind of more complete test
  - Add constants for the module and route names
  - tags

--- a/blockchain/x/liquidator/expected_keepers.go
+++ b/blockchain/x/liquidator/expected_keepers.go
@@ -4,11 +4,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/kava-labs/usdx/blockchain/x/auction"
-	"github.com/kava-labs/usdx/blockchain/x/cdp"
 )
 
 type cdpKeeper interface {
-	SeizeCDP(sdk.Context, sdk.AccAddress, string) (cdp.CDP, sdk.Error)
+	PartialSeizeCDP(sdk.Context, sdk.AccAddress, string, sdk.Int, sdk.Int) sdk.Error
 	ReduceGlobalDebt(sdk.Context, sdk.Int) sdk.Error
 	GetStableDenom() string // TODO can this be removed somehow?
 	GetGovDenom() string

--- a/blockchain/x/liquidator/expected_keepers.go
+++ b/blockchain/x/liquidator/expected_keepers.go
@@ -4,9 +4,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/kava-labs/usdx/blockchain/x/auction"
+	"github.com/kava-labs/usdx/blockchain/x/cdp"
 )
 
 type cdpKeeper interface {
+	GetCDP(sdk.Context, sdk.AccAddress, string) (cdp.CDP, bool)
 	PartialSeizeCDP(sdk.Context, sdk.AccAddress, string, sdk.Int, sdk.Int) sdk.Error
 	ReduceGlobalDebt(sdk.Context, sdk.Int) sdk.Error
 	GetStableDenom() string // TODO can this be removed somehow?

--- a/blockchain/x/liquidator/genesis.go
+++ b/blockchain/x/liquidator/genesis.go
@@ -14,7 +14,7 @@ type GenesisState struct {
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
 		LiquidatorModuleParams{
-			DebtAuctionSize: sdk.NewInt(10000),
+			DebtAuctionSize: sdk.NewInt(1000),
 			CollateralParams: []CollateralParams{
 				{
 					Denom:       "btc",
@@ -22,7 +22,7 @@ func DefaultGenesisState() GenesisState {
 				},
 				{
 					Denom:       "xrp",
-					AuctionSize: sdk.NewInt(10000),
+					AuctionSize: sdk.NewInt(1000),
 				},
 			},
 		},

--- a/blockchain/x/liquidator/genesis.go
+++ b/blockchain/x/liquidator/genesis.go
@@ -1,0 +1,51 @@
+package liquidator
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// GenesisState is the state that must be provided at genesis.
+type GenesisState struct {
+	LiquidatorModuleParams LiquidatorModuleParams `json:"params"`
+}
+
+// DefaultGenesisState returns a default genesis state
+// TODO pick better values
+func DefaultGenesisState() GenesisState {
+	return GenesisState{
+		LiquidatorModuleParams{
+			DebtAuctionSize: sdk.NewInt(10000),
+			CollateralParams: []CollateralParams{
+				{
+					Denom:       "btc",
+					AuctionSize: sdk.NewInt(1),
+				},
+				{
+					Denom:       "xrp",
+					AuctionSize: sdk.NewInt(10000),
+				},
+			},
+		},
+	}
+}
+
+// InitGenesis sets the genesis state in the keeper.
+func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {
+	keeper.setParams(ctx, data.LiquidatorModuleParams)
+}
+
+// ExportGenesis returns a GenesisState for a given context and keeper.
+// TODO write this
+// func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
+// 	return NewGenesisState(keeper.GetSendEnabled(ctx))
+// }
+
+// ValidateGenesis performs basic validation of genesis data returning an error for any failed validation criteria.
+func ValidateGenesis(data GenesisState) error {
+	// TODO
+	// check debt auction size > 0
+	// validate denoms
+	// check no repeated denoms
+	// check collateral auction sizes > 0
+	return nil
+}

--- a/blockchain/x/liquidator/handler.go
+++ b/blockchain/x/liquidator/handler.go
@@ -10,8 +10,8 @@ import (
 func NewHandler(keeper Keeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		switch msg := msg.(type) {
-		case MsgSeizeAndStartCollateralAuction:
-			return handleMsgSeizeAndStartCollateralAuction(ctx, keeper, msg)
+		case MsgStartCollateralAuction:
+			return handleMsgStartCollateralAuction(ctx, keeper, msg)
 		case MsgStartDebtAuction:
 			return handleMsgStartDebtAuction(ctx, keeper)
 		// case MsgStartSurplusAuction:
@@ -23,12 +23,8 @@ func NewHandler(keeper Keeper) sdk.Handler {
 	}
 }
 
-func handleMsgSeizeAndStartCollateralAuction(ctx sdk.Context, keeper Keeper, msg MsgSeizeAndStartCollateralAuction) sdk.Result {
-	err := keeper.SeizeUnderCollateralizedCDP(ctx, msg.CdpOwner, msg.CollateralDenom)
-	if err != nil {
-		return err.Result()
-	}
-	_, err = keeper.StartCollateralAuction(ctx, msg.CdpOwner, msg.CollateralDenom)
+func handleMsgStartCollateralAuction(ctx sdk.Context, keeper Keeper, msg MsgStartCollateralAuction) sdk.Result {
+	_, err := keeper.StartCollateralAuction(ctx, msg.CdpOwner, msg.CollateralDenom)
 	if err != nil {
 		return err.Result()
 	}
@@ -46,8 +42,9 @@ func handleMsgStartDebtAuction(ctx sdk.Context, keeper Keeper) sdk.Result {
 	return sdk.Result{} // TODO tags
 }
 
-// With no stablity and liquidation fees, surplus auctions can never be run.
+// With no stability and liquidation fees, surplus auctions can never be run.
 // func handleMsgStartSurplusAuction(ctx sdk.Context, keeper Keeper) sdk.Result {
+// 	// cancel out any debt and stable coins before trying to start auction
 //  keeper.settleDebt(ctx)
 // 	_, err := keeper.StartSurplusAuction(ctx)
 // 	if err != nil {

--- a/blockchain/x/liquidator/handler.go
+++ b/blockchain/x/liquidator/handler.go
@@ -36,6 +36,9 @@ func handleMsgSeizeAndStartCollateralAuction(ctx sdk.Context, keeper Keeper, msg
 }
 
 func handleMsgStartDebtAuction(ctx sdk.Context, keeper Keeper) sdk.Result {
+	// cancel out any debt and stable coins before trying to start auction
+	keeper.settleDebt(ctx)
+	// start an auction
 	_, err := keeper.StartDebtAuction(ctx)
 	if err != nil {
 		return err.Result()
@@ -45,6 +48,7 @@ func handleMsgStartDebtAuction(ctx sdk.Context, keeper Keeper) sdk.Result {
 
 // With no stablity and liquidation fees, surplus auctions can never be run.
 // func handleMsgStartSurplusAuction(ctx sdk.Context, keeper Keeper) sdk.Result {
+//  keeper.settleDebt(ctx)
 // 	_, err := keeper.StartSurplusAuction(ctx)
 // 	if err != nil {
 // 		return err.Result()

--- a/blockchain/x/liquidator/handler.go
+++ b/blockchain/x/liquidator/handler.go
@@ -10,8 +10,8 @@ import (
 func NewHandler(keeper Keeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		switch msg := msg.(type) {
-		case MsgStartCollateralAuction:
-			return handleMsgStartCollateralAuction(ctx, keeper, msg)
+		case MsgSeizeAndStartCollateralAuction:
+			return handleMsgSeizeAndStartCollateralAuction(ctx, keeper, msg)
 		case MsgStartDebtAuction:
 			return handleMsgStartDebtAuction(ctx, keeper)
 		// case MsgStartSurplusAuction:
@@ -23,12 +23,12 @@ func NewHandler(keeper Keeper) sdk.Handler {
 	}
 }
 
-func handleMsgStartCollateralAuction(ctx sdk.Context, keeper Keeper, msg MsgStartCollateralAuction) sdk.Result {
-	_, err := keeper.StartCollateralAuction(ctx, msg.CdpOwner, msg.CollateralDenom)
+func handleMsgSeizeAndStartCollateralAuction(ctx sdk.Context, keeper Keeper, msg MsgSeizeAndStartCollateralAuction) sdk.Result {
+	_, err := keeper.SeizeAndStartCollateralAuction(ctx, msg.CdpOwner, msg.CollateralDenom)
 	if err != nil {
 		return err.Result()
 	}
-	return sdk.Result{} // TODO tags
+	return sdk.Result{} // TODO tags, return auction ID
 }
 
 func handleMsgStartDebtAuction(ctx sdk.Context, keeper Keeper) sdk.Result {
@@ -39,7 +39,7 @@ func handleMsgStartDebtAuction(ctx sdk.Context, keeper Keeper) sdk.Result {
 	if err != nil {
 		return err.Result()
 	}
-	return sdk.Result{} // TODO tags
+	return sdk.Result{} // TODO tags, return auction ID
 }
 
 // With no stability and liquidation fees, surplus auctions can never be run.

--- a/blockchain/x/liquidator/handler.go
+++ b/blockchain/x/liquidator/handler.go
@@ -14,8 +14,8 @@ func NewHandler(keeper Keeper) sdk.Handler {
 			return handleMsgSeizeAndStartCollateralAuction(ctx, keeper, msg)
 		case MsgStartDebtAuction:
 			return handleMsgStartDebtAuction(ctx, keeper)
-		case MsgStartSurplusAuction:
-			return handleMsgStartSurplusAuction(ctx, keeper)
+		// case MsgStartSurplusAuction:
+		// 	return handleMsgStartSurplusAuction(ctx, keeper)
 		default:
 			errMsg := fmt.Sprintf("Unrecognized liquidator msg type: %T", msg)
 			return sdk.ErrUnknownRequest(errMsg).Result()
@@ -43,10 +43,11 @@ func handleMsgStartDebtAuction(ctx sdk.Context, keeper Keeper) sdk.Result {
 	return sdk.Result{} // TODO tags
 }
 
-func handleMsgStartSurplusAuction(ctx sdk.Context, keeper Keeper) sdk.Result {
-	_, err := keeper.StartSurplusAuction(ctx)
-	if err != nil {
-		return err.Result()
-	}
-	return sdk.Result{} // TODO tags
-}
+// With no stablity and liquidation fees, surplus auctions can never be run.
+// func handleMsgStartSurplusAuction(ctx sdk.Context, keeper Keeper) sdk.Result {
+// 	_, err := keeper.StartSurplusAuction(ctx)
+// 	if err != nil {
+// 		return err.Result()
+// 	}
+// 	return sdk.Result{} // TODO tags
+// }

--- a/blockchain/x/liquidator/keeper.go
+++ b/blockchain/x/liquidator/keeper.go
@@ -174,29 +174,6 @@ func (k Keeper) settleDebt(ctx sdk.Context) sdk.Error {
 
 // ---------- Store Wrappers ----------
 
-func (k Keeper) getSeizedCDPKey(owner sdk.AccAddress, collateralDenom string) []byte {
-	return []byte(owner.String() + collateralDenom)
-}
-func (k Keeper) GetSeizedCDP(ctx sdk.Context, originalOwner sdk.AccAddress, collateralDenom string) (SeizedCDP, bool) {
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(k.getSeizedCDPKey(originalOwner, collateralDenom))
-	if bz == nil {
-		return SeizedCDP{}, false
-	}
-	var seizedCdp SeizedCDP
-	k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &seizedCdp)
-	return seizedCdp, true
-}
-func (k Keeper) setSeizedCDP(ctx sdk.Context, cdp SeizedCDP) {
-	store := ctx.KVStore(k.storeKey)
-	bz := k.cdc.MustMarshalBinaryLengthPrefixed(cdp)
-	store.Set(k.getSeizedCDPKey(cdp.Owner, cdp.CollateralDenom), bz)
-}
-func (k Keeper) deleteSeizedCDP(ctx sdk.Context, cdp SeizedCDP) {
-	store := ctx.KVStore(k.storeKey)
-	store.Delete(k.getSeizedCDPKey(cdp.Owner, cdp.CollateralDenom))
-}
-
 // TODO setting and getting seized debt could be abstracted into add/subtract
 // seized debt is known as Awe in maker
 func (k Keeper) getSeizedDebtKey() []byte {

--- a/blockchain/x/liquidator/keeper.go
+++ b/blockchain/x/liquidator/keeper.go
@@ -38,7 +38,7 @@ func (k Keeper) StartCollateralAuction(ctx sdk.Context, originalOwner sdk.AccAdd
 	// Get Seized CDP
 	seizedCDP, found := k.GetSeizedCDP(ctx, originalOwner, collateralDenom)
 	if !found {
-		return 0, sdk.ErrInternal("CDP not found")
+		return 0, sdk.ErrInternal("seized CDP not found")
 	}
 	// Calculate how much stable coin to try and raise in this auction
 	stableToRaise := sdk.MinInt(seizedCDP.Debt, CollateralAuctionMaxBid)
@@ -97,7 +97,7 @@ func (k Keeper) StartDebtAuction(ctx sdk.Context) (auction.ID, sdk.Error) {
 	return auctionID, nil
 }
 
-// With no stablity and liquidation fees, surplus auctions can never be run.
+// With no stability and liquidation fees, surplus auctions can never be run.
 // StartSurplusAuction sells off excess stable coin in exchange for gov coin, which is burned
 // Known as Vow.flap in maker
 // result: stable coin removed from module account (eventually to buyer), gov coin transferred to module account

--- a/blockchain/x/liquidator/keeper_test.go
+++ b/blockchain/x/liquidator/keeper_test.go
@@ -31,16 +31,19 @@ func TestKeeper_StartCollateralAuction(t *testing.T) {
 func TestKeeper_StartDebtAuction(t *testing.T) {
 	// Setup
 	ctx, k := setupTestKeepers()
-	initSDebt := i(2000)
+	initSDebt := SeizedDebt{i(2000),i(0)}
 	k.liquidatorKeeper.setSeizedDebt(ctx, initSDebt)
 
 	// Execute
 	auctionID, err := k.liquidatorKeeper.StartDebtAuction(ctx)
 
 	// Check
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t,
-		initSDebt.Sub(DebtAuctionSize),
+		SeizedDebt{
+			initSDebt.Total,
+			initSDebt.SentToAuction.Add(DebtAuctionSize),
+		},
 		k.liquidatorKeeper.GetSeizedDebt(ctx),
 	)
 	_, found := k.auctionKeeper.GetAuction(ctx, auctionID)
@@ -72,7 +75,7 @@ func TestKeeper_StartDebtAuction(t *testing.T) {
 func TestKeeper_GetSetSeizedDebt(t *testing.T) {
 	// Setup
 	ctx, k := setupTestKeepers()
-	debt := i(528452456344)
+	debt := SeizedDebt{i(234247645), i(2343)}
 
 	// Run test function
 	k.liquidatorKeeper.setSeizedDebt(ctx, debt)

--- a/blockchain/x/liquidator/keeper_test.go
+++ b/blockchain/x/liquidator/keeper_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kava-labs/usdx/blockchain/x/pricefeed"
 	"github.com/kava-labs/usdx/blockchain/x/cdp"
+	"github.com/kava-labs/usdx/blockchain/x/pricefeed"
 )
 
-func TestKeeper_SeizeAndStartCollateralAuction(t *testing.T) { 
+func TestKeeper_SeizeAndStartCollateralAuction(t *testing.T) {
 	// Setup
 	ctx, k := setupTestKeepers()
 
@@ -45,7 +45,7 @@ func TestKeeper_SeizeAndStartCollateralAuction(t *testing.T) {
 func TestKeeper_StartDebtAuction(t *testing.T) {
 	// Setup
 	ctx, k := setupTestKeepers()
-	initSDebt := SeizedDebt{i(2000),i(0)}
+	initSDebt := SeizedDebt{i(2000), i(0)}
 	k.liquidatorKeeper.setSeizedDebt(ctx, initSDebt)
 
 	// Execute

--- a/blockchain/x/liquidator/keeper_test.go
+++ b/blockchain/x/liquidator/keeper_test.go
@@ -47,27 +47,27 @@ func TestKeeper_StartDebtAuction(t *testing.T) {
 	require.True(t, found)
 }
 
-func TestKeeper_StartSurplusAuction(t *testing.T) {
-	// Setup
-	ctx, k := setupTestKeepers()
-	initSurplus := i(2000)
-	k.liquidatorKeeper.bankKeeper.AddCoins(ctx, k.cdpKeeper.GetLiquidatorAccountAddress(), cs(sdk.NewCoin(k.cdpKeeper.GetStableDenom(), initSurplus)))
-	k.liquidatorKeeper.setSeizedDebt(ctx, i(0))
+// func TestKeeper_StartSurplusAuction(t *testing.T) {
+// 	// Setup
+// 	ctx, k := setupTestKeepers()
+// 	initSurplus := i(2000)
+// 	k.liquidatorKeeper.bankKeeper.AddCoins(ctx, k.cdpKeeper.GetLiquidatorAccountAddress(), cs(sdk.NewCoin(k.cdpKeeper.GetStableDenom(), initSurplus)))
+// 	k.liquidatorKeeper.setSeizedDebt(ctx, i(0))
 
-	// Execute
-	auctionID, err := k.liquidatorKeeper.StartSurplusAuction(ctx)
+// 	// Execute
+// 	auctionID, err := k.liquidatorKeeper.StartSurplusAuction(ctx)
 
-	// Check
-	require.NoError(t, err)
-	require.Equal(t,
-		initSurplus.Sub(SurplusAuctionSize),
-		k.liquidatorKeeper.bankKeeper.GetCoins(ctx,
-			k.cdpKeeper.GetLiquidatorAccountAddress(),
-		).AmountOf(k.cdpKeeper.GetStableDenom()),
-	)
-	_, found := k.auctionKeeper.GetAuction(ctx, auctionID)
-	require.True(t, found)
-}
+// 	// Check
+// 	require.NoError(t, err)
+// 	require.Equal(t,
+// 		initSurplus.Sub(SurplusAuctionSize),
+// 		k.liquidatorKeeper.bankKeeper.GetCoins(ctx,
+// 			k.cdpKeeper.GetLiquidatorAccountAddress(),
+// 		).AmountOf(k.cdpKeeper.GetStableDenom()),
+// 	)
+// 	_, found := k.auctionKeeper.GetAuction(ctx, auctionID)
+// 	require.True(t, found)
+// }
 
 func TestKeeper_GetSetSeizedDebt(t *testing.T) {
 	// Setup

--- a/blockchain/x/liquidator/msg.go
+++ b/blockchain/x/liquidator/msg.go
@@ -10,26 +10,25 @@ Design options and problems:
 	- senders have to pay fees
 	- these msgs cannot be bundled into a tx with a PlaceBid msg because PlaceBid requires an auction ID
  - msgs that start auctions and place an initial bid
-	- couples two processes that may need to be handled separately
+	- place bid can fail, leaving auction without bids which is similar to first case
  - no msgs, auctions started automatically
-	- not clear how this should be done
 	- running this as an endblocker adds complexity and potential vulnerabilities
 */
 
-type MsgSeizeAndStartCollateralAuction struct {
+type MsgStartCollateralAuction struct {
 	Sender          sdk.AccAddress // only needed to pay the tx fees
 	CdpOwner        sdk.AccAddress
 	CollateralDenom string
 }
 
 // Route return the message type used for routing the message.
-func (msg MsgSeizeAndStartCollateralAuction) Route() string { return "liquidator" }
+func (msg MsgStartCollateralAuction) Route() string { return "liquidator" }
 
 // Type returns a human-readable string for the message, intended for utilization within tags.
-func (msg MsgSeizeAndStartCollateralAuction) Type() string { return "seize_and_start_auction" } // TODO snake case?
+func (msg MsgStartCollateralAuction) Type() string { return "start_auction" } // TODO snake case?
 
 // ValidateBasic does a simple validation check that doesn't require access to any other information.
-func (msg MsgSeizeAndStartCollateralAuction) ValidateBasic() sdk.Error {
+func (msg MsgStartCollateralAuction) ValidateBasic() sdk.Error {
 	if msg.Sender.Empty() {
 		return sdk.ErrInternal("invalid (empty) sender address")
 	}
@@ -41,13 +40,13 @@ func (msg MsgSeizeAndStartCollateralAuction) ValidateBasic() sdk.Error {
 }
 
 // GetSignBytes gets the canonical byte representation of the Msg.
-func (msg MsgSeizeAndStartCollateralAuction) GetSignBytes() []byte {
+func (msg MsgStartCollateralAuction) GetSignBytes() []byte {
 	bz := msgCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }
 
 // GetSigners returns the addresses of signers that must sign.
-func (msg MsgSeizeAndStartCollateralAuction) GetSigners() []sdk.AccAddress {
+func (msg MsgStartCollateralAuction) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Sender}
 }
 
@@ -68,7 +67,7 @@ func (msg MsgStartDebtAuction) GetSignBytes() []byte {
 }
 func (msg MsgStartDebtAuction) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.Sender} }
 
-// With no stablity and liquidation fees, surplus auctions can never be run.
+// With no stability and liquidation fees, surplus auctions can never be run.
 // type MsgStartSurplusAuction struct {
 // 	Sender sdk.AccAddress // only needed to pay the tx fees
 // }

--- a/blockchain/x/liquidator/msg.go
+++ b/blockchain/x/liquidator/msg.go
@@ -68,19 +68,20 @@ func (msg MsgStartDebtAuction) GetSignBytes() []byte {
 }
 func (msg MsgStartDebtAuction) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.Sender} }
 
-type MsgStartSurplusAuction struct {
-	Sender sdk.AccAddress // only needed to pay the tx fees
-}
+// With no stablity and liquidation fees, surplus auctions can never be run.
+// type MsgStartSurplusAuction struct {
+// 	Sender sdk.AccAddress // only needed to pay the tx fees
+// }
 
-func (msg MsgStartSurplusAuction) Route() string { return "liquidator" }
-func (msg MsgStartSurplusAuction) Type() string  { return "start_surplus_auction" } // TODO snake case?
-func (msg MsgStartSurplusAuction) ValidateBasic() sdk.Error {
-	if msg.Sender.Empty() {
-		return sdk.ErrInternal("invalid (empty) sender address")
-	}
-	return nil
-}
-func (msg MsgStartSurplusAuction) GetSignBytes() []byte {
-	return sdk.MustSortJSON(msgCdc.MustMarshalJSON(msg))
-}
-func (msg MsgStartSurplusAuction) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.Sender} }
+// func (msg MsgStartSurplusAuction) Route() string { return "liquidator" }
+// func (msg MsgStartSurplusAuction) Type() string  { return "start_surplus_auction" } // TODO snake case?
+// func (msg MsgStartSurplusAuction) ValidateBasic() sdk.Error {
+// 	if msg.Sender.Empty() {
+// 		return sdk.ErrInternal("invalid (empty) sender address")
+// 	}
+// 	return nil
+// }
+// func (msg MsgStartSurplusAuction) GetSignBytes() []byte {
+// 	return sdk.MustSortJSON(msgCdc.MustMarshalJSON(msg))
+// }
+// func (msg MsgStartSurplusAuction) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.Sender} }

--- a/blockchain/x/liquidator/msg.go
+++ b/blockchain/x/liquidator/msg.go
@@ -15,20 +15,20 @@ Design options and problems:
 	- running this as an endblocker adds complexity and potential vulnerabilities
 */
 
-type MsgStartCollateralAuction struct {
+type MsgSeizeAndStartCollateralAuction struct {
 	Sender          sdk.AccAddress // only needed to pay the tx fees
 	CdpOwner        sdk.AccAddress
 	CollateralDenom string
 }
 
 // Route return the message type used for routing the message.
-func (msg MsgStartCollateralAuction) Route() string { return "liquidator" }
+func (msg MsgSeizeAndStartCollateralAuction) Route() string { return "liquidator" }
 
 // Type returns a human-readable string for the message, intended for utilization within tags.
-func (msg MsgStartCollateralAuction) Type() string { return "start_auction" } // TODO snake case?
+func (msg MsgSeizeAndStartCollateralAuction) Type() string { return "seize_and_start_auction" } // TODO snake case?
 
 // ValidateBasic does a simple validation check that doesn't require access to any other information.
-func (msg MsgStartCollateralAuction) ValidateBasic() sdk.Error {
+func (msg MsgSeizeAndStartCollateralAuction) ValidateBasic() sdk.Error {
 	if msg.Sender.Empty() {
 		return sdk.ErrInternal("invalid (empty) sender address")
 	}
@@ -40,13 +40,13 @@ func (msg MsgStartCollateralAuction) ValidateBasic() sdk.Error {
 }
 
 // GetSignBytes gets the canonical byte representation of the Msg.
-func (msg MsgStartCollateralAuction) GetSignBytes() []byte {
+func (msg MsgSeizeAndStartCollateralAuction) GetSignBytes() []byte {
 	bz := msgCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }
 
 // GetSigners returns the addresses of signers that must sign.
-func (msg MsgStartCollateralAuction) GetSigners() []sdk.AccAddress {
+func (msg MsgSeizeAndStartCollateralAuction) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Sender}
 }
 

--- a/blockchain/x/liquidator/params.go
+++ b/blockchain/x/liquidator/params.go
@@ -1,4 +1,4 @@
-package cdp
+package liquidator
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -7,36 +7,36 @@ import (
 
 /*
 How this uses the sdk params module:
- - Put all the params for this module in one struct `CDPModuleParams`
+ - Put all the params for this module in one struct `LiquidatorModuleParams`
  - Store this in the keeper's paramSubspace under one key
  - Provide a function to load the param struct all at once `keeper.GetParams(ctx)`
 It's possible to set individual key value pairs within a paramSubspace, but reading and setting them is awkward (an empty variable needs to be created, then Get writes the value into it)
 This approach will be awkward if we ever need to write individual parameters (because they're stored all together). If this happens do as the sdk modules do - store parameters separately with custom get/set func for each.
 */
 
-type CdpModuleParams struct {
-	GlobalDebtLimit  sdk.Int
+type LiquidatorModuleParams struct {
+	DebtAuctionSize sdk.Int
+	//SurplusAuctionSize sdk.Int
 	CollateralParams []CollateralParams
 }
 
 type CollateralParams struct {
-	Denom            string  // Coin name of collateral type
-	LiquidationRatio sdk.Dec // The ratio (Collateral (priced in stable coin) / Debt) under which a CDP will be liquidated
-	DebtLimit        sdk.Int // Maximum amount of debt allowed to be drawn from this collateral type
-	//DebtFloor        sdk.Int // used to prevent dust
+	Denom       string  // Coin name of collateral type
+	AuctionSize sdk.Int // Max amount of collateral to sell off in any one auction. Known as lump in Maker.
+	// LiquidationPenalty
 }
 
-var moduleParamsKey = []byte("CdpModuleParams")
+var moduleParamsKey = []byte("LiquidatorModuleParams")
 
 func createParamsKeyTable() params.KeyTable {
 	return params.NewKeyTable(
-		moduleParamsKey, CdpModuleParams{},
+		moduleParamsKey, LiquidatorModuleParams{},
 	)
 }
 
 // Helper methods to search the list of collateral params for a particular denom. Wouldn't be needed if amino supported maps.
 
-func (p CdpModuleParams) GetCollateralParams(collateralDenom string) CollateralParams {
+func (p LiquidatorModuleParams) GetCollateralParams(collateralDenom string) CollateralParams {
 	// search for matching denom, return
 	for _, cp := range p.CollateralParams {
 		if cp.Denom == collateralDenom {
@@ -45,13 +45,4 @@ func (p CdpModuleParams) GetCollateralParams(collateralDenom string) CollateralP
 	}
 	// panic if not found, to be safe
 	panic("collateral params not found in module params")
-}
-func (p CdpModuleParams) IsCollateralPresent(collateralDenom string) bool {
-	// search for matching denom, return
-	for _, cp := range p.CollateralParams {
-		if cp.Denom == collateralDenom {
-			return true
-		}
-	}
-	return false
 }

--- a/blockchain/x/liquidator/querier.go
+++ b/blockchain/x/liquidator/querier.go
@@ -7,26 +7,41 @@ import (
 )
 
 const (
-	QueryGetFreeDebt = "freedebt" // Get the free seized debt
+	QueryGetOutstandingDebt = "outstanding_debt" // Get the outstanding seized debt
 )
 
 func NewQuerier(keeper Keeper) sdk.Querier {
 	return func(ctx sdk.Context, path []string, req abci.RequestQuery) (res []byte, err sdk.Error) {
 		switch path[0] {
-		case QueryGetFreeDebt:
-			return queryGetFreeDebt(ctx, path[1:], req, keeper)
+		case QueryGetOutstandingDebt:
+			return queryGetOutstandingDebt(ctx, path[1:], req, keeper)
 		// case QueryGetSurplus:
 		// 	return queryGetSurplus()
 		default:
-			return nil, sdk.ErrUnknownRequest("unknown cdp query endpoint")
+			return nil, sdk.ErrUnknownRequest("unknown liquidator query endpoint")
 		}
 	}
 }
 
-func queryGetFreeDebt(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	freeDebt := keeper.GetSeizedDebt(ctx).Available()
-	bz, err := codec.MarshalJSONIndent(keeper.cdc, freeDebt)
+func queryGetOutstandingDebt(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	// Calculate the remaining seized debt after settling with the liquidator's stable coins.
+	stableCoins := keeper.bankKeeper.GetCoins(
+		ctx,
+		keeper.cdpKeeper.GetLiquidatorAccountAddress(),
+	).AmountOf(keeper.cdpKeeper.GetStableDenom())
+	seizedDebt := keeper.GetSeizedDebt(ctx)
+	settleAmount := sdk.MinInt(seizedDebt.Total, stableCoins)
+	seizedDebt, err := seizedDebt.Settle(settleAmount)
 	if err != nil {
+		return nil, err // this shouldn't error in this context
+	}
+
+	// Get the available debt after settling
+	oustandingDebt := seizedDebt.Available()
+
+	// Encode and return
+	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, oustandingDebt)
+	if err2 != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
 	return bz, nil

--- a/blockchain/x/liquidator/querier.go
+++ b/blockchain/x/liquidator/querier.go
@@ -17,8 +17,6 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return queryGetFreeDebt(ctx, path[1:], req, keeper)
 		// case QueryGetSurplus:
 		// 	return queryGetSurplus()
-		// case QueryGetSeizedCDPs:
-		// 	return queryGetSeizedCDPs()
 		default:
 			return nil, sdk.ErrUnknownRequest("unknown cdp query endpoint")
 		}

--- a/blockchain/x/liquidator/querier.go
+++ b/blockchain/x/liquidator/querier.go
@@ -1,0 +1,35 @@
+package liquidator
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+const (
+	QueryGetFreeDebt = "freedebt" // Get the free seized debt
+)
+
+func NewQuerier(keeper Keeper) sdk.Querier {
+	return func(ctx sdk.Context, path []string, req abci.RequestQuery) (res []byte, err sdk.Error) {
+		switch path[0] {
+		case QueryGetFreeDebt:
+			return queryGetFreeDebt(ctx, path[1:], req, keeper)
+		// case QueryGetSurplus:
+		// 	return queryGetSurplus()
+		// case QueryGetSeizedCDPs:
+		// 	return queryGetSeizedCDPs()
+		default:
+			return nil, sdk.ErrUnknownRequest("unknown cdp query endpoint")
+		}
+	}
+}
+
+func queryGetFreeDebt(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	freeDebt := keeper.GetSeizedDebt(ctx).Available()
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, freeDebt)
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
+	}
+	return bz, nil
+}

--- a/blockchain/x/liquidator/test_common.go
+++ b/blockchain/x/liquidator/test_common.go
@@ -80,8 +80,15 @@ func setupTestKeepers() (sdk.Context, keepers) {
 		pricefeedKeeper,
 		bankKeeper,
 	)
-	auctionKeeper := auction.NewKeeper(cdc, cdpKeeper, keyAuction)                         // Note: cdp keeper stands in for bank keeper
-	liquidatorKeeper := NewKeeper(cdc, keyLiquidator, cdpKeeper, auctionKeeper, cdpKeeper) // Note: cdp keeper stands in for bank keeper
+	auctionKeeper := auction.NewKeeper(cdc, cdpKeeper, keyAuction) // Note: cdp keeper stands in for bank keeper
+	liquidatorKeeper := NewKeeper(
+		cdc,
+		keyLiquidator,
+		paramsKeeper.Subspace("liquidatorSubspace"),
+		cdpKeeper,
+		auctionKeeper,
+		cdpKeeper,
+	) // Note: cdp keeper stands in for bank keeper
 
 	// Create context
 	ctx := sdk.NewContext(ms, abci.Header{ChainID: "testchain"}, false, log.NewNopLogger())
@@ -90,6 +97,7 @@ func setupTestKeepers() (sdk.Context, keepers) {
 	// TODO move out of this function
 	// auth genesis - requires fee keeper
 	cdp.InitGenesis(ctx, cdpKeeper, cdp.DefaultGenesisState())
+	InitGenesis(ctx, liquidatorKeeper, DefaultGenesisState())
 
 	return ctx, keepers{
 		paramsKeeper,

--- a/blockchain/x/liquidator/test_common.go
+++ b/blockchain/x/liquidator/test_common.go
@@ -93,12 +93,6 @@ func setupTestKeepers() (sdk.Context, keepers) {
 	// Create context
 	ctx := sdk.NewContext(ms, abci.Header{ChainID: "testchain"}, false, log.NewNopLogger())
 
-	// Setup all the state within the keepers (including genesis)
-	// TODO move out of this function
-	// auth genesis - requires fee keeper
-	cdp.InitGenesis(ctx, cdpKeeper, cdp.DefaultGenesisState())
-	InitGenesis(ctx, liquidatorKeeper, DefaultGenesisState())
-
 	return ctx, keepers{
 		paramsKeeper,
 		accountKeeper,

--- a/blockchain/x/liquidator/test_common.go
+++ b/blockchain/x/liquidator/test_common.go
@@ -57,7 +57,7 @@ func setupTestKeepers() (sdk.Context, keepers) {
 	}
 
 	// Create Codec
-	cdc := MakeTestCodec()
+	cdc := makeTestCodec()
 
 	// Create Keepers
 	paramsKeeper := params.NewKeeper(cdc, keyParams, tkeyParams)
@@ -102,7 +102,7 @@ func setupTestKeepers() (sdk.Context, keepers) {
 	}
 }
 
-func MakeTestCodec() *codec.Codec {
+func makeTestCodec() *codec.Codec {
 	var cdc = codec.New()
 	auth.RegisterCodec(cdc)
 	bank.RegisterCodec(cdc)

--- a/blockchain/x/liquidator/types.go
+++ b/blockchain/x/liquidator/types.go
@@ -1,7 +1,19 @@
 package liquidator
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/kava-labs/usdx/blockchain/x/cdp"
 )
 
 type SeizedCDP = cdp.CDP // TODO is this a reasonable thing to do?
+
+type SeizedDebt struct {
+	Total         sdk.Int // Total debt seized from CDPs. Known as Awe in maker.
+	SentToAuction sdk.Int // Portion of seized debt that has had a (reverse) auction was started for it. Known as Ash in maker.
+}
+
+// Available gets the seized debt that has not been sent for auction. Known as Woe in maker.
+func (sd SeizedDebt) Available() sdk.Int {
+	return sd.Total.Sub(sd.SentToAuction)
+}

--- a/blockchain/x/liquidator/types.go
+++ b/blockchain/x/liquidator/types.go
@@ -2,11 +2,7 @@ package liquidator
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/kava-labs/usdx/blockchain/x/cdp"
 )
-
-type SeizedCDP = cdp.CDP // TODO is this a reasonable thing to do?
 
 type SeizedDebt struct {
 	Total         sdk.Int // Total debt seized from CDPs. Known as Awe in maker.

--- a/blockchain/x/liquidator/types.go
+++ b/blockchain/x/liquidator/types.go
@@ -7,9 +7,22 @@ import (
 type SeizedDebt struct {
 	Total         sdk.Int // Total debt seized from CDPs. Known as Awe in maker.
 	SentToAuction sdk.Int // Portion of seized debt that has had a (reverse) auction was started for it. Known as Ash in maker.
+	// SentToAuction should always be < Total
 }
 
 // Available gets the seized debt that has not been sent for auction. Known as Woe in maker.
 func (sd SeizedDebt) Available() sdk.Int {
 	return sd.Total.Sub(sd.SentToAuction)
+}
+
+func (sd SeizedDebt) Settle(amount sdk.Int) (SeizedDebt, sdk.Error) {
+	if amount.IsNegative() {
+		return sd, sdk.ErrInternal("tried to settle a negative amount")
+	}
+	if amount.GT(sd.Total) {
+		return sd, sdk.ErrInternal("tried to settle more debt than exists")
+	}
+	sd.Total = sd.Total.Sub(amount)
+	sd.SentToAuction = sdk.MaxInt(sd.SentToAuction.Sub(amount), sdk.ZeroInt())
+	return sd, nil
 }


### PR DESCRIPTION
Main changes:
 - CDPs are no longer seized in one go. Once under the liquidation ratio anyone can seiz a fixed amount of the collateral and debt from a CDP and start an auction.
 - Surplus auctions have been disabled - turns out without fees it's impossible to get a surplus.
 - Liquidator module now has querier, cli and rest.
 - Liquidator parameters have been moved to param subspace thing rather than being hard coded.